### PR TITLE
Update mongodb driver to 3.6 in preparation for migration from mLab to Atlas

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "marked": "^0.3.5",
     "method-override": "^2.3.5",
     "moment": "^2.10.6",
-    "mongodb": "^2.0.41",
+    "mongodb": "^3.6.0",
     "node-sass": "^3.4.2",
     "passport": "^0.2.2",
     "passport-google-oauth": "^0.2.0",


### PR DESCRIPTION
See https://docs.mlab.com/how-to-migrate-sandbox-heroku-addons-to-atlas/ guide (prerequisites section) and the compatibility grid for the node driver here: https://docs.mongodb.com/drivers/node/compatibility